### PR TITLE
Some fixes to imports and names.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,64 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*,cover
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# IDE configs
+.idea/
+
+# Juypter Notebook Checkpoitns
+.ipynb_checkpoints
+.pytest_cache

--- a/sparsemf/__init__.py
+++ b/sparsemf/__init__.py
@@ -1,4 +1,4 @@
 from .sparse_soft_impute import SoftImpute
-from .sparse_als_soft_impute import SoftImputeALS
+from .sparse_als_soft_impute import SparseSoftImputeALS
 from .sparse_biscale import SBiScale
 from .splr_matrix import SPLR

--- a/sparsemf/sparse_als_soft_impute.py
+++ b/sparsemf/sparse_als_soft_impute.py
@@ -19,9 +19,9 @@ from sklearn.utils.extmath import randomized_svd
 from scipy.sparse import coo_matrix, csc_matrix, issparse, csr_matrix
 from sklearn.metrics import mean_squared_error
 
-from sparse_biscale import SBiScale
-from sparse_solver import Solver
-from splr_matrix import SPLR
+from .sparse_biscale import SBiScale
+from .sparse_solver import Solver
+from .splr_matrix import SPLR
 from sklearn.base import TransformerMixin
     
 

--- a/sparsemf/sparse_biscale.py
+++ b/sparsemf/sparse_biscale.py
@@ -106,7 +106,7 @@ class SBiScale(object):
         '''    
         self._add_variables(x)
         self._center_scale_I()
-        for i in xrange(self.maxit):
+        for i in range(self.maxit):
             # Centering
             ## Column mean
             if self.col_center:

--- a/sparsemf/sparse_soft_impute.py
+++ b/sparsemf/sparse_soft_impute.py
@@ -19,9 +19,9 @@ from sklearn.utils.extmath import randomized_svd
 from scipy.sparse import coo_matrix, csc_matrix, issparse, csr_matrix
 from sklearn.metrics import mean_squared_error
 
-from sparse_biscale import SBiScale
-from sparse_solver import Solver
-from splr_matrix import SPLR
+from .sparse_biscale import SBiScale
+from .sparse_solver import Solver
+from .splr_matrix import SPLR
     
 
 class SoftImpute(Solver):
@@ -119,7 +119,7 @@ class SoftImpute(Solver):
         row_ids, col_ids, _ = self.missing_mask
         x_svd = self.X_fill
         targets = zip(row_ids, col_ids)
-        n_preds = len(targets)
+        n_preds = len(list(targets))
         res = np.empty(n_preds)
 
         for idx, (r, c) in enumerate(targets):

--- a/sparsemf/sparse_solver.py
+++ b/sparsemf/sparse_solver.py
@@ -15,7 +15,7 @@ from __future__ import absolute_import, print_function, division
 import numpy as np
 from six.moves import range
 from scipy.sparse import issparse, coo_matrix, csr_matrix
-from sparse_biscale import SBiScale
+from .sparse_biscale import SBiScale
 
 
 class Solver(object):

--- a/tests/test_soft_impute.py
+++ b/tests/test_soft_impute.py
@@ -1,5 +1,5 @@
 import numpy as np
-from sparse_soft_impute import SoftImpute, SPLR
+from sparsemf import SoftImpute, SPLR
 from scipy.sparse import coo_matrix, csr_matrix, csc_matrix, lil_matrix
 from sklearn.utils.testing import assert_raises, assert_equal, assert_array_equal
 import unittest


### PR DESCRIPTION
I have tried using sparseMF in python 3, but ran into many problems. I am not sure if this is an issue between python 2 vs. python 3 (I only tried python 3).

1) Many import statements were missing the required "." in front of the name
2) The name SoftImputeALS does not exist, but only SparseSoftImputeALS
3) The code is using xrange, which is deprecated in python3. Some other python3 issues with len on zip (see below)
4) The tests are not running (did not manage to fix them)
5) The documentation is not correct. There is no model.fit(X) method, but only a complete() method (at least looking at the test cases this seems to be the intended use).

It would be really helpful if you could make sure that the package is working on python 3 together with the test cases and an up-to-date minimal documentation on how to use it.

Thanks a lot!
Christian